### PR TITLE
Double CPU speed while negotiating handshake with backend

### DIFF
--- a/third_party/nopoll/nopoll_mbedtls_shim.c
+++ b/third_party/nopoll/nopoll_mbedtls_shim.c
@@ -279,7 +279,6 @@ int mbedtls_library_init(mbedtls_ssl_context *ssl, mbedtls_ssl_config *conf, mbe
         }
     }
 
-    ssl_speed_up_exit();
 
     /* mbedtls_printf( " ok\n" ); */
 
@@ -303,6 +302,8 @@ int mbedtls_library_init(mbedtls_ssl_context *ssl, mbedtls_ssl_config *conf, mbe
     /*     mbedtls_printf( " ok\n" ); */
 
 exit:
+
+    ssl_speed_up_exit();
 
 #ifdef MBEDTLS_ERROR_C
     if( ret != 0 )


### PR DESCRIPTION
(stolen from Expressif's openssl shim around mbedtls)

I wasn't able to compile this, as I don't have the dev environment set up, but I think it'll work. Curious to see if there's a noticeable difference in speed when negotiating TLS.